### PR TITLE
Fix `compileClasspath` with project.files

### DIFF
--- a/compat-patrouille-gradle-plugin/src/main/kotlin/compat/patrouille/internal/CompatPatrouilleExtensionImpl.kt
+++ b/compat-patrouille-gradle-plugin/src/main/kotlin/compat/patrouille/internal/CompatPatrouilleExtensionImpl.kt
@@ -57,7 +57,7 @@ internal abstract class CompatPatrouilleExtensionImpl(private val project: Proje
       warningAsError = project.provider { severity == Severity.ERROR },
       kotlinVersion = project.provider { kotlinVersion ?: project.getKotlinPluginVersion() },
       taskName = "compatPatrouilleCheckApiDependencies",
-      compileClasspath = configurationProvider.get(),
+      compileClasspath = project.files(configurationProvider),
     )
 
     project.tasks.named("check").configure {


### PR DESCRIPTION
Wrap `configurationProvider` with `project.files()` to correctly resolve the file collection lazily.