### PR TITLE
Make task names and error messages more consistent and deprecate check{Api/Runtime}Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ tapmoc {
   // Kotlin takes a string so you have more control of the patch release of the stdlib.
   // languageVersion/apiVersion are configured with the minor version only.
   kotlin("2.1.0")
+
+  // Optional: fail the build if any api dependency exposes incompatible Kotlin metadata, Kotlin stdlib or Java bytecode version.
+  checkDependencies()
 }
 ```
 
@@ -85,14 +88,12 @@ That's it, you can now keep on with your life.
 
 Enforcing compiler flags works for your own code but doesn't check your dependencies. They may use incompatible APIs that will crash at runtime and/or produce incompatible metadata that will crash at build time.
 
-You can have tapmoc fail in such cases with `checkApiDependencies` or `checkRuntimeDependencies`:
+You can have tapmoc fail in such cases with `checkDependencies`:
 
 ```kotlin
 tapmoc {
-  // Fail the build if any api dependency exposes incompatible Kotlin metadata.
-  checkApiDependencies(Severity.ERROR)
-  // Fail the build if any runtime dependency relies on an incompatible kotlin-stdlib version.
-  checkRuntimeDependencies(Severity.ERROR)
+  // Fail the build if any api dependency exposes incompatible Kotlin metadata, Kotlin stdlib or Java bytecode version.
+  checkDependencies()
 }
 ```
 

--- a/tapmoc-gradle-plugin/api/tapmoc-gradle-plugin.api
+++ b/tapmoc-gradle-plugin/api/tapmoc-gradle-plugin.api
@@ -14,6 +14,7 @@ public final class tapmoc/Severity : java/lang/Enum {
 
 public abstract interface class tapmoc/TapmocExtension {
 	public abstract fun checkApiDependencies (Ltapmoc/Severity;)V
+	public abstract fun checkDependencies ()V
 	public abstract fun checkDependencies (Ltapmoc/Severity;)V
 	public abstract fun checkRuntimeDependencies (Ltapmoc/Severity;)V
 	public abstract fun java (I)V

--- a/tapmoc-gradle-plugin/src/main/kotlin/tapmoc/TapmocExtension.kt
+++ b/tapmoc-gradle-plugin/src/main/kotlin/tapmoc/TapmocExtension.kt
@@ -9,7 +9,7 @@ interface TapmocExtension {
    * - release (if not on android)
    *
    * @param version the version of Java to target.
-   * Examples: 8, 11, 17, 21, 24,...
+   * Examples: 8, 11, 17, 21, 24, ...
    */
   fun java(version: Int)
 
@@ -24,37 +24,37 @@ interface TapmocExtension {
    * @param version the version of Kotlin to target.
    * This is a string in case you need a specific minor version in `coreLibrariesVersion`
    *
-   * Examples: "1.9.0", "1.9.22", "2.0.21", "2.1.20",...
+   * Examples: "1.9.0", "1.9.22", "2.0.21", "2.1.20", ...
    */
   fun kotlin(version: String)
 
-  /**
-   * Makes `tapmocCheckApiDependencies` walk all the api dependencies transitively
-   * and check that the metadata version in the `META-INF/${lib}.kotlin_module` file is compatible with
-   * the specified kotlin version.
-   * This is version n + 1 thanks to kotlinc n + 1 forward compatibility.
-   *
-   * @param severity what to do when a dependency is found to be incompatible.
-   */
+  @Deprecated("Use checkDependencies instead.", ReplaceWith("checkDependencies(severity)"))
   fun checkApiDependencies(severity: Severity)
 
-  /**
-   * Makes `tapmocCheckRuntimeDependencies` walk all the runtime dependencies transitively
-   * and checks that `kotlin-stdlib` is not upgraded to a version > n
-   *
-   * @param severity what to do when a dependency is found to be incompatible.
-   */
+  @Deprecated("Use checkDependencies instead.", ReplaceWith("checkDependencies(severity)"))
   fun checkRuntimeDependencies(severity: Severity)
 
   /**
-   * Calls both `checkpiDependencies(severity)` and `checkRuntimeDependencies(severity)`.
+   * Walks the consumable configurations exposing a `java-api` or `java-runtime` [usage attribute](https://docs.gradle.org/9.2.1/javadoc/org/gradle/api/attributes/Usage.html)
+   * and checks that dependencies are compatible with the target [java] and [kotlin] values:
    *
-   * ```kotlin
-   * checkApiDependencies(severity)
-   * checkRuntimeDependencies(severity)
-   * ```
+   * - checks that `kotlin-stdlib` is always <= targetKotlinVersion (`java-runtime` only)
+   * - checks that Kotlin metadata is always <= targetKotlinVersion + 1 (`java-api` only).
+   * Note: it is `targetKotlinVersion + 1` because Kotlin has a [best effort n + 1 forward compatibility guarantee](https://kotlinlang.org/docs/kotlin-evolution-principles.html#evolving-the-binary-format).
+   * - checks that the Java class files version is always <= targetJavaVersion
    */
   fun checkDependencies(severity: Severity)
+
+  /**
+   * Walks the consumable configurations exposing a `java-api` or `java-runtime` [usage attribute](https://docs.gradle.org/9.2.1/javadoc/org/gradle/api/attributes/Usage.html)
+   * and checks that dependencies are compatible with the target [java] and [kotlin] values:
+   *
+   * - checks that `kotlin-stdlib` is always <= targetKotlinVersion (`java-runtime` only)
+   * - checks that Kotlin metadata is always <= targetKotlinVersion + 1 (`java-api` only).
+   * Note: it is `targetKotlinVersion + 1` because Kotlin has a [best effort n + 1 forward compatibility guarantee](https://kotlinlang.org/docs/kotlin-evolution-principles.html#evolving-the-binary-format).
+   * - checks that the Java class files version is always <= targetJavaVersion
+   */
+  fun checkDependencies()
 }
 
 enum class Severity {

--- a/tapmoc-gradle-plugin/src/main/kotlin/tapmoc/compatibility.kt
+++ b/tapmoc-gradle-plugin/src/main/kotlin/tapmoc/compatibility.kt
@@ -36,7 +36,7 @@ fun Project.configureKotlinCompatibility(
   version: String,
 ) {
   require(version.split(".").size == 3) {
-    "Cannot parse Kotlin version '$version'. Expected format is X.Y.Z."
+    "Tapmoc: cannot parse Kotlin version '$version'. Expected format is X.Y.Z."
   }
 
   kgp()?.kotlinCompatibility(version)

--- a/tapmoc-tasks/api/tapmoc-tasks.api
+++ b/tapmoc-tasks/api/tapmoc-tasks.api
@@ -1,30 +1,30 @@
-public final class tapmoc/task/CheckJavaClassFilesVersionEntryPoint {
-	public static final field Companion Ltapmoc/task/CheckJavaClassFilesVersionEntryPoint$Companion;
+public final class tapmoc/task/TapmocCheckClassFileVersionsEntryPoint {
+	public static final field Companion Ltapmoc/task/TapmocCheckClassFileVersionsEntryPoint$Companion;
 	public fun <init> ()V
 	public static final fun run (Ljava/util/function/BiConsumer;ZLjava/util/List;Ljava/lang/Integer;Ljava/io/File;)V
 }
 
-public final class tapmoc/task/CheckJavaClassFilesVersionEntryPoint$Companion {
+public final class tapmoc/task/TapmocCheckClassFileVersionsEntryPoint$Companion {
 	public final fun run (Ljava/util/function/BiConsumer;ZLjava/util/List;Ljava/lang/Integer;Ljava/io/File;)V
 }
 
-public final class tapmoc/task/CheckKotlinMetadataEntryPoint {
-	public static final field Companion Ltapmoc/task/CheckKotlinMetadataEntryPoint$Companion;
+public final class tapmoc/task/TapmocCheckKotlinMetadataVersionsEntryPoint {
+	public static final field Companion Ltapmoc/task/TapmocCheckKotlinMetadataVersionsEntryPoint$Companion;
 	public fun <init> ()V
 	public static final fun run (Ljava/util/function/BiConsumer;ZLjava/lang/String;Ljava/util/List;Ljava/io/File;)V
 }
 
-public final class tapmoc/task/CheckKotlinMetadataEntryPoint$Companion {
+public final class tapmoc/task/TapmocCheckKotlinMetadataVersionsEntryPoint$Companion {
 	public final fun run (Ljava/util/function/BiConsumer;ZLjava/lang/String;Ljava/util/List;Ljava/io/File;)V
 }
 
-public final class tapmoc/task/CheckKotlinStdlibVersionsEntryPoint {
-	public static final field Companion Ltapmoc/task/CheckKotlinStdlibVersionsEntryPoint$Companion;
+public final class tapmoc/task/TapmocCheckKotlinStdlibVersionsEntryPoint {
+	public static final field Companion Ltapmoc/task/TapmocCheckKotlinStdlibVersionsEntryPoint$Companion;
 	public fun <init> ()V
 	public static final fun run (Ljava/util/function/BiConsumer;ZLjava/lang/String;Ljava/util/Set;Ljava/io/File;)V
 }
 
-public final class tapmoc/task/CheckKotlinStdlibVersionsEntryPoint$Companion {
+public final class tapmoc/task/TapmocCheckKotlinStdlibVersionsEntryPoint$Companion {
 	public final fun run (Ljava/util/function/BiConsumer;ZLjava/lang/String;Ljava/util/Set;Ljava/io/File;)V
 }
 

--- a/tapmoc-tasks/src/main/kotlin/tapmoc/task/checkClassFileVersions.kt
+++ b/tapmoc-tasks/src/main/kotlin/tapmoc/task/checkClassFileVersions.kt
@@ -10,7 +10,7 @@ import org.objectweb.asm.Opcodes
 import java.util.zip.ZipInputStream
 
 @GTask
-internal fun checkJavaClassFilesVersion(
+internal fun tapmocCheckClassFileVersions(
   logger: GLogger,
   warningAsError: Boolean,
   jarFiles: GInputFiles,
@@ -18,7 +18,7 @@ internal fun checkJavaClassFilesVersion(
   output: GOutputFile
 ) {
   if (javaVersion == null) {
-    output.writeText("Tapmoc: skip checking class files version as no target java version is defined")
+    output.writeText("Tapmoc: skip checking class file versions as no target Java version is defined")
     return
   }
   val maxAllowedClassFileVersion = 44 + javaVersion

--- a/tapmoc-tasks/src/main/kotlin/tapmoc/task/checkKotlinMetadataVersions.kt
+++ b/tapmoc-tasks/src/main/kotlin/tapmoc/task/checkKotlinMetadataVersions.kt
@@ -12,7 +12,7 @@ import kotlin.metadata.jvm.UnstableMetadataApi
 
 @OptIn(UnstableMetadataApi::class)
 @GTask
-internal fun checkKotlinMetadata(
+internal fun tapmocCheckKotlinMetadataVersions(
   logger: GLogger,
   warningAsError: Boolean,
   kotlinVersion: String?,
@@ -20,7 +20,7 @@ internal fun checkKotlinMetadata(
   output: GOutputFile
 ) {
   if (kotlinVersion == null) {
-    output.writeText("Tapmoc: skip checking kotlin metadata version as no target kotlin version is defined")
+    output.writeText("Tapmoc: skip checking Kotlin metadata versions as no target Kotlin version is defined")
     return
   }
 

--- a/tapmoc-tasks/src/main/kotlin/tapmoc/task/checkKotlinStdlibVersions.kt
+++ b/tapmoc-tasks/src/main/kotlin/tapmoc/task/checkKotlinStdlibVersions.kt
@@ -5,7 +5,7 @@ import gratatouille.tasks.GOutputFile
 import gratatouille.tasks.GTask
 
 @GTask
-internal fun checkKotlinStdlibVersions(
+internal fun tapmocCheckKotlinStdlibVersions(
   logger: GLogger,
   warningAsError: Boolean,
   kotlinVersion: String?,
@@ -13,7 +13,7 @@ internal fun checkKotlinStdlibVersions(
   output: GOutputFile
 ) {
   if (kotlinVersion == null) {
-    output.writeText("Tapmoc: skip checking kotlin metadata version as no target kotlin version is defined")
+    output.writeText("Tapmoc: skip checking Kotlin stdlib versions as no target Kotlin version is defined")
     return
   }
 

--- a/tests/build-logic/src/main/kotlin/check-publication.kt
+++ b/tests/build-logic/src/main/kotlin/check-publication.kt
@@ -107,7 +107,7 @@ fun checkPublication(m2Files: GInputFiles, jvmTarget: Int, kotlinMetadataVersion
 
 @OptIn(UnstableMetadataApi::class)
 private fun checkJarFile(name: String, inputStream: InputStream, jvmTarget: Int, kotlinMetadataVersion: String?) {
-  println("checkJarFile '$name'")
+  //println("checkJarFile '$name'")
   ZipInputStream(inputStream).let { zis ->
     var entry = zis.nextEntry
     while (entry != null) {


### PR DESCRIPTION
Use simple `checkDependencies()` instead.