### PR TITLE
React to the `com.android.test` plugin

### DIFF
--- a/tapmoc-gradle-plugin/src/agp/kotlin/tapmoc/internal/AgpImpl.kt
+++ b/tapmoc-gradle-plugin/src/agp/kotlin/tapmoc/internal/AgpImpl.kt
@@ -37,5 +37,6 @@ internal fun Project.onAgp(block: (Agp) -> Unit) {
   }
   pluginManager.withPlugin("com.android.application", callback)
   pluginManager.withPlugin("com.android.library", callback)
+  pluginManager.withPlugin("com.android.test", callback)
   pluginManager.withPlugin("com.android.kotlin.multiplatform.library", callback)
 }


### PR DESCRIPTION
Add missing `com.android.test` to AGP callbacks