### PR TITLE
Simplify parsing the Gradle major version a bit

### DIFF
--- a/tapmoc-gradle-plugin/src/main/kotlin/tapmoc/internal/gradle.kt
+++ b/tapmoc-gradle-plugin/src/main/kotlin/tapmoc/internal/gradle.kt
@@ -35,13 +35,15 @@ internal fun javaVersionForGradle(major: Int): Int {
 
 internal fun parseGradleMajorVersion(gradleVersion: String): Int {
   val c = gradleVersion.split('.')
-  check (c.isNotEmpty()) {
+  val d = c.firstOrNull()
+
+  checkNotNull(d) {
     "Tapmoc: gradleVersion should be in the form `major[.minor[.patch]]` (found '$gradleVersion')"
   }
 
-  val major = c.get(0).toIntOrNull()
+  val major = d.toIntOrNull()
 
-  check (major != null) {
+  checkNotNull(major) {
     "Tapmoc: major version must be an integer (found '$major' in '$gradleVersion')"
   }
 


### PR DESCRIPTION
This implicitly addresses the inspection hint to not use `get(0)` in favor if the index operator.